### PR TITLE
feat(services): add mDNS discovery service (#40)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Required for mDNS / network service discovery (bonsoir). -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation" />
+
     <application
         android:label="opencode_remote_app"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,5 +66,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>This app needs local network access to discover OpenCode servers on your network.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_opencode._tcp</string>
+	</array>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -70,7 +70,7 @@
 	<string>This app needs local network access to discover OpenCode servers on your network.</string>
 	<key>NSBonjourServices</key>
 	<array>
-		<string>_opencode._tcp</string>
+		<string>_http._tcp</string>
 	</array>
 </dict>
 </plist>

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -2,7 +2,7 @@ class AppConstants {
   AppConstants._();
 
   static const String appName = 'OpenCode Remote';
-  static const String mdnsServiceType = '_opencode._tcp';
+  static const String mdnsServiceType = '_http._tcp';
   static const Duration healthPollingInterval = Duration(seconds: 30);
   static const int maxReconnectAttempts = 5;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
+
 import 'core/theme/app_theme.dart';
-import 'presentation/widgets/app_bar/terminal_app_bar.dart';
+import 'presentation/screens/connect/discovery_debug_screen.dart';
 
 void main() {
   runApp(const App());
@@ -14,19 +15,7 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: 'OpenCode Remote',
       theme: AppTheme.dark(),
-      home: const PlaceholderScreen(),
-    );
-  }
-}
-
-class PlaceholderScreen extends StatelessWidget {
-  const PlaceholderScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: TerminalAppBar(title: 'OpenCode Remote'),
-      body: Center(child: Text('OpenCode Remote App')),
+      home: const DiscoveryDebugScreen(),
     );
   }
 }

--- a/lib/presentation/screens/connect/discovery_debug_screen.dart
+++ b/lib/presentation/screens/connect/discovery_debug_screen.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_typography.dart';
+import '../../../services/services.dart';
+import '../../widgets/app_bar/terminal_app_bar.dart';
+
+/// Debug screen for manually exercising [MdnsService].
+///
+/// Not a production UI: it exists so we can confirm mDNS discovery works
+/// end-to-end against a real `opencode serve --mdns` instance before the
+/// real connect screen lands in a later ticket.
+class DiscoveryDebugScreen extends StatefulWidget {
+  const DiscoveryDebugScreen({super.key});
+
+  @override
+  State<DiscoveryDebugScreen> createState() => _DiscoveryDebugScreenState();
+}
+
+class _DiscoveryDebugScreenState extends State<DiscoveryDebugScreen> {
+  final MdnsService _mdns = MdnsService();
+  StreamSubscription<List<DiscoveredServer>>? _subscription;
+  List<DiscoveredServer> _servers = const [];
+  Object? _error;
+  bool _isDiscovering = false;
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    unawaited(_mdns.dispose());
+    super.dispose();
+  }
+
+  void _start() {
+    setState(() {
+      _error = null;
+      _isDiscovering = true;
+    });
+    try {
+      final stream = _mdns.startDiscovery();
+      _subscription = stream.listen(
+        (servers) {
+          setState(() => _servers = servers);
+        },
+        onError: (Object error) {
+          setState(() {
+            _error = error;
+            _isDiscovering = false;
+          });
+        },
+      );
+    } catch (error) {
+      setState(() {
+        _error = error;
+        _isDiscovering = false;
+      });
+    }
+  }
+
+  Future<void> _stop() async {
+    await _subscription?.cancel();
+    _subscription = null;
+    await _mdns.stopDiscovery();
+    if (!mounted) return;
+    setState(() {
+      _isDiscovering = false;
+      _servers = const [];
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const TerminalAppBar(
+        title: 'mDNS Discovery',
+        showConnectionBadge: false,
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _isDiscovering ? null : _start,
+                    child: const Text('Start'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: _isDiscovering ? _stop : null,
+                    child: const Text('Stop'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: _ErrorBanner(message: _error.toString()),
+            ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                Text(
+                  _isDiscovering ? 'DISCOVERING' : 'IDLE',
+                  style: AppTypography.label.copyWith(
+                    color: _isDiscovering
+                        ? AppColors.success
+                        : AppColors.textMuted,
+                  ),
+                ),
+                const Spacer(),
+                Text(
+                  '${_servers.length} server(s)',
+                  style: AppTypography.label,
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1, color: AppColors.border),
+          Expanded(
+            child: _servers.isEmpty
+                ? Center(
+                    child: Text(
+                      _isDiscovering
+                          ? 'Searching for servers…'
+                          : 'No servers yet.\nTap Start to begin discovery.',
+                      textAlign: TextAlign.center,
+                      style: AppTypography.bodyMedium,
+                    ),
+                  )
+                : ListView.separated(
+                    itemCount: _servers.length,
+                    separatorBuilder: (_, _) =>
+                        const Divider(height: 1, color: AppColors.border),
+                    itemBuilder: (context, index) =>
+                        _ServerTile(server: _servers[index]),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ServerTile extends StatelessWidget {
+  const _ServerTile({required this.server});
+
+  final DiscoveredServer server;
+
+  @override
+  Widget build(BuildContext context) {
+    final attributes = server.attributes;
+    return ListTile(
+      title: Text(server.name, style: AppTypography.titleMedium),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${server.host}:${server.port}',
+            style: AppTypography.codeSmall,
+          ),
+          if (attributes.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                attributes.entries
+                    .map((e) => '${e.key}=${e.value}')
+                    .join('  '),
+                style: AppTypography.bodySmall,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.error.withValues(alpha: 0.12),
+        border: Border.all(color: AppColors.error),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        message,
+        style: AppTypography.bodyMedium.copyWith(color: AppColors.error),
+      ),
+    );
+  }
+}

--- a/lib/services/discovered_server.dart
+++ b/lib/services/discovered_server.dart
@@ -1,0 +1,44 @@
+/// A resolved OpenCode server advertised on the local network via mDNS.
+///
+/// Equality is keyed on [name] + [host] + [port]. The TXT-record [attributes]
+/// are excluded from equality because they can legitimately change (e.g. a
+/// `version` bump) without representing a different server — including them
+/// would break the upsert semantics in `MdnsService`.
+class DiscoveredServer {
+  const DiscoveredServer({
+    required this.name,
+    required this.host,
+    required this.port,
+    this.attributes = const {},
+  });
+
+  /// Service name advertised by the server (e.g. `"OpenCode on laptop"`).
+  final String name;
+
+  /// Resolved host or IP literal. Non-null: only constructed once the
+  /// underlying bonsoir service has been resolved.
+  final String host;
+
+  /// TCP port the server listens on.
+  final int port;
+
+  /// TXT-record attributes (e.g. version, path). Never null; empty by default.
+  final Map<String, String> attributes;
+
+  /// Stable identifier used by `MdnsService` to upsert/remove entries.
+  String get key => '$name|$host|$port';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DiscoveredServer &&
+          other.name == name &&
+          other.host == host &&
+          other.port == port);
+
+  @override
+  int get hashCode => Object.hash(name, host, port);
+
+  @override
+  String toString() => 'DiscoveredServer(name: $name, host: $host:$port)';
+}

--- a/lib/services/mdns_service.dart
+++ b/lib/services/mdns_service.dart
@@ -71,7 +71,6 @@ class MdnsService {
 
     try {
       await discovery.initialize();
-      await discovery.start();
     } catch (error, stackTrace) {
       Logger.error(
         'mDNS discovery failed to start',
@@ -90,6 +89,11 @@ class MdnsService {
     final stream = discovery.eventStream;
     if (stream == null) {
       Logger.warning('mDNS discovery eventStream is null');
+      _isDiscovering = false;
+      _discovery = null;
+      _controller.addError(
+        const NetworkException('mDNS discovery event stream is unavailable'),
+      );
       return;
     }
 
@@ -107,6 +111,24 @@ class MdnsService {
         );
       },
     );
+
+    try {
+      await discovery.start();
+    } catch (error, stackTrace) {
+      Logger.error(
+        'mDNS discovery failed to start',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      _isDiscovering = false;
+      await _subscription?.cancel();
+      _subscription = null;
+      _discovery = null;
+      _controller.addError(
+        NetworkException('mDNS discovery failed to start: $error', stackTrace),
+        stackTrace,
+      );
+    }
   }
 
   void _handleEvent(BonsoirDiscoveryEvent event) {

--- a/lib/services/mdns_service.dart
+++ b/lib/services/mdns_service.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+
+import 'package:bonsoir/bonsoir.dart';
+
+import '../core/constants/app_constants.dart';
+import '../core/errors/errors.dart';
+import '../core/utils/logger.dart';
+import 'discovered_server.dart';
+
+/// Builds a [BonsoirDiscovery] for the given service type. Injected by tests
+/// so they can substitute a [Fake] without a mocking library.
+typedef BonsoirDiscoveryFactory = BonsoirDiscovery Function(String type);
+
+/// Discovers OpenCode servers advertised on the local network via mDNS/DNS-SD.
+///
+/// Lifecycle: `startDiscovery()` → (stream events) → `stopDiscovery()` — may be
+/// repeated — then `dispose()` to release the stream controller for good.
+class MdnsService {
+  MdnsService({
+    BonsoirDiscoveryFactory? discoveryFactory,
+    String serviceType = AppConstants.mdnsServiceType,
+  }) : _discoveryFactory =
+           discoveryFactory ?? ((type) => BonsoirDiscovery(type: type)),
+       _serviceType = serviceType;
+
+  final BonsoirDiscoveryFactory _discoveryFactory;
+  final String _serviceType;
+
+  final Map<String, DiscoveredServer> _servers = {};
+  final StreamController<List<DiscoveredServer>> _controller =
+      StreamController<List<DiscoveredServer>>.broadcast();
+  late final Stream<List<DiscoveredServer>> _stream = _controller.stream;
+
+  BonsoirDiscovery? _discovery;
+  StreamSubscription<BonsoirDiscoveryEvent>? _subscription;
+  bool _isDiscovering = false;
+  bool _isDisposed = false;
+
+  /// Whether discovery is currently active.
+  bool get isDiscovering => _isDiscovering;
+
+  /// Snapshot of currently known servers. Immutable view.
+  List<DiscoveredServer> get discoveredServers =>
+      List.unmodifiable(_servers.values);
+
+  /// Starts mDNS discovery and returns a broadcast stream of snapshots.
+  ///
+  /// Idempotent: a second call while discovery is already running returns the
+  /// existing stream. Throws [StateError] after [dispose]. Throws
+  /// [NetworkException] if bonsoir fails to initialize or start.
+  Stream<List<DiscoveredServer>> startDiscovery() {
+    if (_isDisposed) {
+      throw StateError('MdnsService has been disposed');
+    }
+    if (_isDiscovering) {
+      return _stream;
+    }
+
+    // Assigned synchronously so this method returns a stream immediately;
+    // the async initialize/start runs in the background and errors surface
+    // via `_controller.addError` (or rethrow to the unhandled zone if no
+    // listener yet). See `_beginDiscovery` for the error path.
+    _isDiscovering = true;
+    unawaited(_beginDiscovery());
+    return _stream;
+  }
+
+  Future<void> _beginDiscovery() async {
+    final discovery = _discoveryFactory(_serviceType);
+    _discovery = discovery;
+
+    try {
+      await discovery.initialize();
+      await discovery.start();
+    } catch (error, stackTrace) {
+      Logger.error(
+        'mDNS discovery failed to start',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      _isDiscovering = false;
+      _discovery = null;
+      _controller.addError(
+        NetworkException('mDNS discovery failed to start: $error', stackTrace),
+        stackTrace,
+      );
+      return;
+    }
+
+    final stream = discovery.eventStream;
+    if (stream == null) {
+      Logger.warning('mDNS discovery eventStream is null');
+      return;
+    }
+
+    _subscription = stream.listen(
+      _handleEvent,
+      onError: (Object error, StackTrace stackTrace) {
+        Logger.error(
+          'mDNS discovery stream error',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        _controller.addError(
+          NetworkException('mDNS stream error: $error', stackTrace),
+          stackTrace,
+        );
+      },
+    );
+  }
+
+  void _handleEvent(BonsoirDiscoveryEvent event) {
+    switch (event) {
+      case BonsoirDiscoveryStartedEvent():
+        Logger.info('mDNS discovery started');
+      case BonsoirDiscoveryServiceFoundEvent(:final service):
+        Logger.debug(
+          'mDNS service found',
+          context: {'name': service.name, 'port': service.port},
+        );
+        _resolveIfPossible(service);
+      case BonsoirDiscoveryServiceResolvedEvent(:final service):
+        _upsert(service);
+      case BonsoirDiscoveryServiceUpdatedEvent(:final service):
+        _upsert(service);
+      case BonsoirDiscoveryServiceResolveFailedEvent():
+        Logger.warning('mDNS service resolve failed');
+      case BonsoirDiscoveryServiceLostEvent(:final service):
+        _remove(service);
+      case BonsoirDiscoveryStoppedEvent():
+        Logger.info('mDNS discovery stopped');
+      case BonsoirDiscoveryUnknownEvent():
+        Logger.warning('mDNS unknown discovery event');
+    }
+  }
+
+  void _resolveIfPossible(BonsoirService service) {
+    final resolver = _discovery?.serviceResolver;
+    if (resolver == null) {
+      return;
+    }
+    try {
+      resolver.resolveService(service);
+    } catch (error, stackTrace) {
+      Logger.warning(
+        'mDNS resolveService failed',
+        error: error,
+        stackTrace: stackTrace,
+        context: {'name': service.name},
+      );
+    }
+  }
+
+  void _upsert(BonsoirService service) {
+    final host = service.host;
+    if (host == null) {
+      return;
+    }
+    final entry = DiscoveredServer(
+      name: service.name,
+      host: host,
+      port: service.port,
+      attributes: Map<String, String>.from(service.attributes),
+    );
+    _servers[entry.key] = entry;
+    _emit();
+  }
+
+  void _remove(BonsoirService service) {
+    final host = service.host;
+    if (host != null) {
+      final keyed = '${service.name}|$host|${service.port}';
+      if (_servers.remove(keyed) != null) {
+        _emit();
+        return;
+      }
+    }
+    // Host may be null on lost events: fall back to name+port match.
+    String? matchKey;
+    for (final entry in _servers.values) {
+      if (entry.name == service.name && entry.port == service.port) {
+        matchKey = entry.key;
+        break;
+      }
+    }
+    if (matchKey != null) {
+      _servers.remove(matchKey);
+      _emit();
+    }
+  }
+
+  void _emit() {
+    if (_controller.isClosed) {
+      return;
+    }
+    _controller.add(List.unmodifiable(_servers.values));
+  }
+
+  /// Stops active discovery. No-op when not running. Safe to call repeatedly.
+  /// Does not close the underlying stream controller (use [dispose] for that).
+  Future<void> stopDiscovery() async {
+    if (!_isDiscovering) {
+      return;
+    }
+    _isDiscovering = false;
+
+    await _subscription?.cancel();
+    _subscription = null;
+
+    final discovery = _discovery;
+    _discovery = null;
+    if (discovery != null) {
+      try {
+        await discovery.stop();
+      } catch (error, stackTrace) {
+        Logger.warning(
+          'mDNS discovery stop failed',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+
+    _servers.clear();
+    _emit();
+  }
+
+  /// Releases all resources. Subsequent calls to [startDiscovery] throw
+  /// [StateError]. Safe to call multiple times.
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    await stopDiscovery();
+    _isDisposed = true;
+    await _controller.close();
+  }
+}

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -1,0 +1,2 @@
+export 'discovered_server.dart';
+export 'mdns_service.dart';

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -26,6 +26,12 @@
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>This app needs local network access to discover OpenCode servers on your network.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_http._tcp</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/test/unit/services/mdns_service_test.dart
+++ b/test/unit/services/mdns_service_test.dart
@@ -78,31 +78,40 @@ void main() {
         await fake.subscribedCompleter.future;
         expect(fake.initializeCalled, isTrue);
         expect(fake.startCalled, isTrue);
+        expect(fake.callOrder, containsAllInOrder(['initialize', 'start']));
+      });
+
+      test('subscribes to event stream before starting discovery', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
         expect(
           fake.callOrder,
-          containsAllInOrder(['initialize', 'start']),
+          containsAllInOrder(['initialize', 'listen', 'start']),
         );
       });
 
-      test('returns a broadcast stream (multiple listeners receive events)',
-          () async {
-        final stream = service.startDiscovery();
-        await fake.subscribedCompleter.future;
+      test(
+        'returns a broadcast stream (multiple listeners receive events)',
+        () async {
+          final stream = service.startDiscovery();
+          await fake.subscribedCompleter.future;
 
-        final snapshotsA = <List<DiscoveredServer>>[];
-        final snapshotsB = <List<DiscoveredServer>>[];
-        final subA = stream.listen(snapshotsA.add);
-        final subB = stream.listen(snapshotsB.add);
+          final snapshotsA = <List<DiscoveredServer>>[];
+          final snapshotsB = <List<DiscoveredServer>>[];
+          final subA = stream.listen(snapshotsA.add);
+          final subB = stream.listen(snapshotsB.add);
 
-        fake.emit(_resolved('svc', '10.0.0.1', 4096));
-        await _pump();
+          fake.emit(_resolved('svc', '10.0.0.1', 4096));
+          await _pump();
 
-        expect(snapshotsA, hasLength(1));
-        expect(snapshotsB, hasLength(1));
+          expect(snapshotsA, hasLength(1));
+          expect(snapshotsB, hasLength(1));
 
-        await subA.cancel();
-        await subB.cancel();
-      });
+          await subA.cancel();
+          await subB.cancel();
+        },
+      );
 
       test('sets isDiscovering to true', () async {
         service.startDiscovery();
@@ -110,33 +119,38 @@ void main() {
         expect(service.isDiscovering, isTrue);
       });
 
-      test('a second call returns the same broadcast stream (idempotent)',
-          () async {
-        final a = service.startDiscovery();
-        await fake.subscribedCompleter.future;
-        final b = service.startDiscovery();
-        expect(identical(a, b), isTrue);
-        expect(fake.initializeCallCount, 1);
-        expect(fake.startCallCount, 1);
-      });
+      test(
+        'a second call returns the same broadcast stream (idempotent)',
+        () async {
+          final a = service.startDiscovery();
+          await fake.subscribedCompleter.future;
+          final b = service.startDiscovery();
+          expect(identical(a, b), isTrue);
+          expect(fake.initializeCallCount, 1);
+          expect(fake.startCallCount, 1);
+        },
+      );
 
       test('emits NetworkException on stream when initialize fails', () async {
         fake.throwOnInitialize = Exception('init-boom');
         final stream = service.startDiscovery();
-        await expectLater(
-          stream,
-          emitsError(isA<NetworkException>()),
-        );
+        await expectLater(stream, emitsError(isA<NetworkException>()));
         expect(service.isDiscovering, isFalse);
       });
 
       test('emits NetworkException on stream when start fails', () async {
         fake.throwOnStart = Exception('start-boom');
         final stream = service.startDiscovery();
-        await expectLater(
-          stream,
-          emitsError(isA<NetworkException>()),
-        );
+        await expectLater(stream, emitsError(isA<NetworkException>()));
+        expect(service.isDiscovering, isFalse);
+      });
+
+      test('emits NetworkException when eventStream is unavailable', () async {
+        fake.exposeEventStream = false;
+        final stream = service.startDiscovery();
+
+        await expectLater(stream, emitsError(isA<NetworkException>()));
+
         expect(service.isDiscovering, isFalse);
       });
 
@@ -155,7 +169,7 @@ void main() {
           BonsoirDiscoveryServiceFoundEvent(
             service: BonsoirService.ignoreNorms(
               name: 'svc',
-              type: '_opencode._tcp',
+              type: '_http._tcp',
               port: 4096,
             ),
           ),
@@ -181,35 +195,31 @@ void main() {
         await sub.cancel();
       });
 
-      test('ServiceResolvedEvent with same key replaces existing entry',
-          () async {
-        service.startDiscovery();
-        await fake.subscribedCompleter.future;
+      test(
+        'ServiceResolvedEvent with same key replaces existing entry',
+        () async {
+          service.startDiscovery();
+          await fake.subscribedCompleter.future;
 
-        fake.emit(
-          _resolved('svc', '10.0.0.1', 4096, attributes: {'v': '1'}),
-        );
-        fake.emit(
-          _resolved('svc', '10.0.0.1', 4096, attributes: {'v': '2'}),
-        );
-        await _pump();
+          fake.emit(_resolved('svc', '10.0.0.1', 4096, attributes: {'v': '1'}));
+          fake.emit(_resolved('svc', '10.0.0.1', 4096, attributes: {'v': '2'}));
+          await _pump();
 
-        expect(service.discoveredServers, hasLength(1));
-        expect(service.discoveredServers.single.attributes['v'], '2');
-      });
+          expect(service.discoveredServers, hasLength(1));
+          expect(service.discoveredServers.single.attributes['v'], '2');
+        },
+      );
 
       test('ServiceUpdatedEvent with resolved host updates entry', () async {
         service.startDiscovery();
         await fake.subscribedCompleter.future;
 
-        fake.emit(
-          _resolved('svc', '10.0.0.1', 4096, attributes: {'v': '1'}),
-        );
+        fake.emit(_resolved('svc', '10.0.0.1', 4096, attributes: {'v': '1'}));
         fake.emit(
           BonsoirDiscoveryServiceUpdatedEvent(
             service: BonsoirService.ignoreNorms(
               name: 'svc',
-              type: '_opencode._tcp',
+              type: '_http._tcp',
               host: '10.0.0.1',
               port: 4096,
               attributes: const {'v': '2'},
@@ -229,7 +239,7 @@ void main() {
           BonsoirDiscoveryServiceUpdatedEvent(
             service: BonsoirService.ignoreNorms(
               name: 'svc',
-              type: '_opencode._tcp',
+              type: '_http._tcp',
               port: 4096,
             ),
           ),
@@ -239,48 +249,52 @@ void main() {
         expect(service.discoveredServers, isEmpty);
       });
 
-      test('ServiceLostEvent removes the entry and emits an empty snapshot',
-          () async {
-        service.startDiscovery();
-        await fake.subscribedCompleter.future;
-        fake.emit(_resolved('svc', '10.0.0.1', 4096));
-        await _pump();
+      test(
+        'ServiceLostEvent removes the entry and emits an empty snapshot',
+        () async {
+          service.startDiscovery();
+          await fake.subscribedCompleter.future;
+          fake.emit(_resolved('svc', '10.0.0.1', 4096));
+          await _pump();
 
-        fake.emit(
-          BonsoirDiscoveryServiceLostEvent(
-            service: BonsoirService.ignoreNorms(
-              name: 'svc',
-              type: '_opencode._tcp',
-              host: '10.0.0.1',
-              port: 4096,
+          fake.emit(
+            BonsoirDiscoveryServiceLostEvent(
+              service: BonsoirService.ignoreNorms(
+                name: 'svc',
+                type: '_http._tcp',
+                host: '10.0.0.1',
+                port: 4096,
+              ),
             ),
-          ),
-        );
-        await _pump();
+          );
+          await _pump();
 
-        expect(service.discoveredServers, isEmpty);
-      });
+          expect(service.discoveredServers, isEmpty);
+        },
+      );
 
-      test('ServiceLostEvent with null host falls back to name+port match',
-          () async {
-        service.startDiscovery();
-        await fake.subscribedCompleter.future;
-        fake.emit(_resolved('svc', '10.0.0.1', 4096));
-        await _pump();
+      test(
+        'ServiceLostEvent with null host falls back to name+port match',
+        () async {
+          service.startDiscovery();
+          await fake.subscribedCompleter.future;
+          fake.emit(_resolved('svc', '10.0.0.1', 4096));
+          await _pump();
 
-        fake.emit(
-          BonsoirDiscoveryServiceLostEvent(
-            service: BonsoirService.ignoreNorms(
-              name: 'svc',
-              type: '_opencode._tcp',
-              port: 4096,
+          fake.emit(
+            BonsoirDiscoveryServiceLostEvent(
+              service: BonsoirService.ignoreNorms(
+                name: 'svc',
+                type: '_http._tcp',
+                port: 4096,
+              ),
             ),
-          ),
-        );
-        await _pump();
+          );
+          await _pump();
 
-        expect(service.discoveredServers, isEmpty);
-      });
+          expect(service.discoveredServers, isEmpty);
+        },
+      );
 
       test('ServiceLostEvent for unknown service is a no-op', () async {
         service.startDiscovery();
@@ -292,7 +306,7 @@ void main() {
           BonsoirDiscoveryServiceLostEvent(
             service: BonsoirService.ignoreNorms(
               name: 'unknown',
-              type: '_opencode._tcp',
+              type: '_http._tcp',
               host: '10.0.0.9',
               port: 4096,
             ),
@@ -326,10 +340,7 @@ void main() {
       test('stream onError is forwarded via NetworkException', () async {
         final stream = service.startDiscovery();
         final errors = <Object>[];
-        final sub = stream.listen(
-          (_) {},
-          onError: errors.add,
-        );
+        final sub = stream.listen((_) {}, onError: errors.add);
         await fake.subscribedCompleter.future;
 
         fake.emitError(Exception('underlying-stream-boom'));
@@ -343,16 +354,18 @@ void main() {
     });
 
     group('stopDiscovery', () {
-      test('calls stop on the discovery and flips isDiscovering to false',
-          () async {
-        service.startDiscovery();
-        await fake.subscribedCompleter.future;
+      test(
+        'calls stop on the discovery and flips isDiscovering to false',
+        () async {
+          service.startDiscovery();
+          await fake.subscribedCompleter.future;
 
-        await service.stopDiscovery();
+          await service.stopDiscovery();
 
-        expect(fake.stopCalled, isTrue);
-        expect(service.isDiscovering, isFalse);
-      });
+          expect(fake.stopCalled, isTrue);
+          expect(service.isDiscovering, isFalse);
+        },
+      );
 
       test('emits an empty snapshot after stopping', () async {
         final stream = service.startDiscovery();
@@ -379,8 +392,7 @@ void main() {
     });
 
     group('dispose', () {
-      test('stops active discovery and closes the stream controller',
-          () async {
+      test('stops active discovery and closes the stream controller', () async {
         final stream = service.startDiscovery();
         final sub = stream.listen((_) {});
         await fake.subscribedCompleter.future;
@@ -409,7 +421,7 @@ BonsoirDiscoveryServiceResolvedEvent _resolved(
   return BonsoirDiscoveryServiceResolvedEvent(
     service: BonsoirService.ignoreNorms(
       name: name,
-      type: '_opencode._tcp',
+      type: '_http._tcp',
       host: host,
       port: port,
       attributes: attributes,
@@ -429,6 +441,7 @@ class _FakeDiscovery extends Fake implements BonsoirDiscovery {
   _FakeDiscovery() {
     _events = StreamController<BonsoirDiscoveryEvent>.broadcast(
       onListen: () {
+        callOrder.add('listen');
         if (!subscribedCompleter.isCompleted) {
           subscribedCompleter.complete();
         }
@@ -445,6 +458,7 @@ class _FakeDiscovery extends Fake implements BonsoirDiscovery {
   bool initializeCalled = false;
   bool startCalled = false;
   bool stopCalled = false;
+  bool exposeEventStream = true;
 
   Object? throwOnInitialize;
   Object? throwOnStart;
@@ -479,7 +493,8 @@ class _FakeDiscovery extends Fake implements BonsoirDiscovery {
   }
 
   @override
-  Stream<BonsoirDiscoveryEvent>? get eventStream => _events.stream;
+  Stream<BonsoirDiscoveryEvent>? get eventStream =>
+      exposeEventStream ? _events.stream : null;
 
   void emit(BonsoirDiscoveryEvent event) => _events.add(event);
 

--- a/test/unit/services/mdns_service_test.dart
+++ b/test/unit/services/mdns_service_test.dart
@@ -1,0 +1,493 @@
+import 'dart:async';
+
+import 'package:bonsoir/bonsoir.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opencode_remote_app/core/errors/errors.dart';
+import 'package:opencode_remote_app/services/discovered_server.dart';
+import 'package:opencode_remote_app/services/mdns_service.dart';
+
+void main() {
+  group('DiscoveredServer', () {
+    test('equality is based on name, host and port (attributes ignored)', () {
+      const a = DiscoveredServer(
+        name: 'svc',
+        host: '10.0.0.1',
+        port: 4096,
+        attributes: {'v': '1'},
+      );
+      const b = DiscoveredServer(
+        name: 'svc',
+        host: '10.0.0.1',
+        port: 4096,
+        attributes: {'v': '2'},
+      );
+      const c = DiscoveredServer(name: 'svc', host: '10.0.0.2', port: 4096);
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('hashCode is consistent with equality', () {
+      const a = DiscoveredServer(name: 'svc', host: '10.0.0.1', port: 4096);
+      const b = DiscoveredServer(name: 'svc', host: '10.0.0.1', port: 4096);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('toString returns a readable format', () {
+      const s = DiscoveredServer(name: 'svc', host: '10.0.0.1', port: 4096);
+      expect(s.toString(), 'DiscoveredServer(name: svc, host: 10.0.0.1:4096)');
+    });
+  });
+
+  group('MdnsService', () {
+    late _FakeDiscovery fake;
+    late MdnsService service;
+
+    setUp(() {
+      fake = _FakeDiscovery();
+      service = MdnsService(discoveryFactory: (_) => fake);
+    });
+
+    tearDown(() async {
+      await service.dispose();
+      await fake.dispose();
+    });
+
+    group('initial state', () {
+      test('isDiscovering is false', () {
+        expect(service.isDiscovering, isFalse);
+      });
+
+      test('discoveredServers is empty', () {
+        expect(service.discoveredServers, isEmpty);
+      });
+
+      test('discoveredServers returns an unmodifiable list', () {
+        expect(
+          () => service.discoveredServers.add(
+            const DiscoveredServer(name: 'x', host: 'h', port: 1),
+          ),
+          throwsUnsupportedError,
+        );
+      });
+    });
+
+    group('startDiscovery', () {
+      test('calls initialize then start on the underlying discovery', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+        expect(fake.initializeCalled, isTrue);
+        expect(fake.startCalled, isTrue);
+        expect(
+          fake.callOrder,
+          containsAllInOrder(['initialize', 'start']),
+        );
+      });
+
+      test('returns a broadcast stream (multiple listeners receive events)',
+          () async {
+        final stream = service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        final snapshotsA = <List<DiscoveredServer>>[];
+        final snapshotsB = <List<DiscoveredServer>>[];
+        final subA = stream.listen(snapshotsA.add);
+        final subB = stream.listen(snapshotsB.add);
+
+        fake.emit(_resolved('svc', '10.0.0.1', 4096));
+        await _pump();
+
+        expect(snapshotsA, hasLength(1));
+        expect(snapshotsB, hasLength(1));
+
+        await subA.cancel();
+        await subB.cancel();
+      });
+
+      test('sets isDiscovering to true', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+        expect(service.isDiscovering, isTrue);
+      });
+
+      test('a second call returns the same broadcast stream (idempotent)',
+          () async {
+        final a = service.startDiscovery();
+        await fake.subscribedCompleter.future;
+        final b = service.startDiscovery();
+        expect(identical(a, b), isTrue);
+        expect(fake.initializeCallCount, 1);
+        expect(fake.startCallCount, 1);
+      });
+
+      test('emits NetworkException on stream when initialize fails', () async {
+        fake.throwOnInitialize = Exception('init-boom');
+        final stream = service.startDiscovery();
+        await expectLater(
+          stream,
+          emitsError(isA<NetworkException>()),
+        );
+        expect(service.isDiscovering, isFalse);
+      });
+
+      test('emits NetworkException on stream when start fails', () async {
+        fake.throwOnStart = Exception('start-boom');
+        final stream = service.startDiscovery();
+        await expectLater(
+          stream,
+          emitsError(isA<NetworkException>()),
+        );
+        expect(service.isDiscovering, isFalse);
+      });
+
+      test('throws StateError after dispose', () async {
+        await service.dispose();
+        expect(service.startDiscovery, throwsStateError);
+      });
+    });
+
+    group('event handling', () {
+      test('ServiceFoundEvent does not add to discoveredServers', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        fake.emit(
+          BonsoirDiscoveryServiceFoundEvent(
+            service: BonsoirService.ignoreNorms(
+              name: 'svc',
+              type: '_opencode._tcp',
+              port: 4096,
+            ),
+          ),
+        );
+        await _pump();
+
+        expect(service.discoveredServers, isEmpty);
+      });
+
+      test('ServiceResolvedEvent adds a DiscoveredServer and emits', () async {
+        final stream = service.startDiscovery();
+        final snapshots = <List<DiscoveredServer>>[];
+        final sub = stream.listen(snapshots.add);
+        await fake.subscribedCompleter.future;
+
+        fake.emit(_resolved('svc', '10.0.0.1', 4096));
+        await _pump();
+
+        expect(service.discoveredServers, hasLength(1));
+        expect(service.discoveredServers.single.host, '10.0.0.1');
+        expect(snapshots.last, hasLength(1));
+
+        await sub.cancel();
+      });
+
+      test('ServiceResolvedEvent with same key replaces existing entry',
+          () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        fake.emit(
+          _resolved('svc', '10.0.0.1', 4096, attributes: {'v': '1'}),
+        );
+        fake.emit(
+          _resolved('svc', '10.0.0.1', 4096, attributes: {'v': '2'}),
+        );
+        await _pump();
+
+        expect(service.discoveredServers, hasLength(1));
+        expect(service.discoveredServers.single.attributes['v'], '2');
+      });
+
+      test('ServiceUpdatedEvent with resolved host updates entry', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        fake.emit(
+          _resolved('svc', '10.0.0.1', 4096, attributes: {'v': '1'}),
+        );
+        fake.emit(
+          BonsoirDiscoveryServiceUpdatedEvent(
+            service: BonsoirService.ignoreNorms(
+              name: 'svc',
+              type: '_opencode._tcp',
+              host: '10.0.0.1',
+              port: 4096,
+              attributes: const {'v': '2'},
+            ),
+          ),
+        );
+        await _pump();
+
+        expect(service.discoveredServers.single.attributes['v'], '2');
+      });
+
+      test('ServiceUpdatedEvent with null host is ignored', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        fake.emit(
+          BonsoirDiscoveryServiceUpdatedEvent(
+            service: BonsoirService.ignoreNorms(
+              name: 'svc',
+              type: '_opencode._tcp',
+              port: 4096,
+            ),
+          ),
+        );
+        await _pump();
+
+        expect(service.discoveredServers, isEmpty);
+      });
+
+      test('ServiceLostEvent removes the entry and emits an empty snapshot',
+          () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+        fake.emit(_resolved('svc', '10.0.0.1', 4096));
+        await _pump();
+
+        fake.emit(
+          BonsoirDiscoveryServiceLostEvent(
+            service: BonsoirService.ignoreNorms(
+              name: 'svc',
+              type: '_opencode._tcp',
+              host: '10.0.0.1',
+              port: 4096,
+            ),
+          ),
+        );
+        await _pump();
+
+        expect(service.discoveredServers, isEmpty);
+      });
+
+      test('ServiceLostEvent with null host falls back to name+port match',
+          () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+        fake.emit(_resolved('svc', '10.0.0.1', 4096));
+        await _pump();
+
+        fake.emit(
+          BonsoirDiscoveryServiceLostEvent(
+            service: BonsoirService.ignoreNorms(
+              name: 'svc',
+              type: '_opencode._tcp',
+              port: 4096,
+            ),
+          ),
+        );
+        await _pump();
+
+        expect(service.discoveredServers, isEmpty);
+      });
+
+      test('ServiceLostEvent for unknown service is a no-op', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+        fake.emit(_resolved('known', '10.0.0.1', 4096));
+        await _pump();
+
+        fake.emit(
+          BonsoirDiscoveryServiceLostEvent(
+            service: BonsoirService.ignoreNorms(
+              name: 'unknown',
+              type: '_opencode._tcp',
+              host: '10.0.0.9',
+              port: 4096,
+            ),
+          ),
+        );
+        await _pump();
+
+        expect(service.discoveredServers, hasLength(1));
+      });
+
+      test('ResolveFailedEvent does not crash', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        fake.emit(const BonsoirDiscoveryServiceResolveFailedEvent());
+        await _pump();
+
+        expect(service.discoveredServers, isEmpty);
+      });
+
+      test('UnknownEvent does not crash', () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        fake.emit(const BonsoirDiscoveryUnknownEvent(id: 'weird'));
+        await _pump();
+
+        expect(service.discoveredServers, isEmpty);
+      });
+
+      test('stream onError is forwarded via NetworkException', () async {
+        final stream = service.startDiscovery();
+        final errors = <Object>[];
+        final sub = stream.listen(
+          (_) {},
+          onError: errors.add,
+        );
+        await fake.subscribedCompleter.future;
+
+        fake.emitError(Exception('underlying-stream-boom'));
+        await _pump();
+
+        expect(errors, hasLength(1));
+        expect(errors.single, isA<NetworkException>());
+
+        await sub.cancel();
+      });
+    });
+
+    group('stopDiscovery', () {
+      test('calls stop on the discovery and flips isDiscovering to false',
+          () async {
+        service.startDiscovery();
+        await fake.subscribedCompleter.future;
+
+        await service.stopDiscovery();
+
+        expect(fake.stopCalled, isTrue);
+        expect(service.isDiscovering, isFalse);
+      });
+
+      test('emits an empty snapshot after stopping', () async {
+        final stream = service.startDiscovery();
+        final snapshots = <List<DiscoveredServer>>[];
+        final sub = stream.listen(snapshots.add);
+        await fake.subscribedCompleter.future;
+
+        fake.emit(_resolved('svc', '10.0.0.1', 4096));
+        await _pump();
+
+        await service.stopDiscovery();
+        await _pump();
+
+        expect(snapshots.last, isEmpty);
+        expect(service.discoveredServers, isEmpty);
+
+        await sub.cancel();
+      });
+
+      test('is a no-op when not currently discovering', () async {
+        await service.stopDiscovery();
+        expect(fake.stopCalled, isFalse);
+      });
+    });
+
+    group('dispose', () {
+      test('stops active discovery and closes the stream controller',
+          () async {
+        final stream = service.startDiscovery();
+        final sub = stream.listen((_) {});
+        await fake.subscribedCompleter.future;
+
+        await service.dispose();
+
+        expect(fake.stopCalled, isTrue);
+        expect(service.startDiscovery, throwsStateError);
+        await sub.cancel();
+      });
+
+      test('is safe to call multiple times', () async {
+        await service.dispose();
+        await service.dispose();
+      });
+    });
+  });
+}
+
+BonsoirDiscoveryServiceResolvedEvent _resolved(
+  String name,
+  String host,
+  int port, {
+  Map<String, String> attributes = const {},
+}) {
+  return BonsoirDiscoveryServiceResolvedEvent(
+    service: BonsoirService.ignoreNorms(
+      name: name,
+      type: '_opencode._tcp',
+      host: host,
+      port: port,
+      attributes: attributes,
+    ),
+  );
+}
+
+/// Yields control so the async event pipeline can process queued events.
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+class _FakeServiceResolver with ServiceResolver {
+  @override
+  Future<void> resolveService(BonsoirService service) async {}
+}
+
+class _FakeDiscovery extends Fake implements BonsoirDiscovery {
+  _FakeDiscovery() {
+    _events = StreamController<BonsoirDiscoveryEvent>.broadcast(
+      onListen: () {
+        if (!subscribedCompleter.isCompleted) {
+          subscribedCompleter.complete();
+        }
+      },
+    );
+  }
+
+  late final StreamController<BonsoirDiscoveryEvent> _events;
+  final Completer<void> subscribedCompleter = Completer<void>();
+  final List<String> callOrder = [];
+
+  int initializeCallCount = 0;
+  int startCallCount = 0;
+  bool initializeCalled = false;
+  bool startCalled = false;
+  bool stopCalled = false;
+
+  Object? throwOnInitialize;
+  Object? throwOnStart;
+
+  @override
+  ServiceResolver get serviceResolver => _FakeServiceResolver();
+
+  @override
+  Future<void> initialize() async {
+    initializeCallCount++;
+    initializeCalled = true;
+    callOrder.add('initialize');
+    if (throwOnInitialize != null) {
+      throw throwOnInitialize!;
+    }
+  }
+
+  @override
+  Future<void> start() async {
+    startCallCount++;
+    startCalled = true;
+    callOrder.add('start');
+    if (throwOnStart != null) {
+      throw throwOnStart!;
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalled = true;
+    callOrder.add('stop');
+  }
+
+  @override
+  Stream<BonsoirDiscoveryEvent>? get eventStream => _events.stream;
+
+  void emit(BonsoirDiscoveryEvent event) => _events.add(event);
+
+  void emitError(Object error) => _events.addError(error);
+
+  Future<void> dispose() async {
+    if (!_events.isClosed) {
+      await _events.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements `MdnsService` and `DiscoveredServer` under `lib/services/` using bonsoir ^6.0.2
- Adds `lib/services/services.dart` barrel (first file in the services layer)
- Adds unit tests with an injected `FakeBonsoirDiscovery` (no mocking library)

Closes #40

## Test plan
- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test test/unit/services/mdns_service_test.dart` — 29 tests pass
- [x] Full suite `flutter test` — 197 tests pass
- [ ] Manual mDNS discovery validated against `opencode serve --mdns` (optional)